### PR TITLE
Changed the strategy for aws credentials and replaced some deprecated API

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "akka-persistence-s3"
 
-scalaVersion := "2.11.8"
+scalaVersion := "2.12.4"
 
 organization := "io.findify"
 
@@ -8,15 +8,15 @@ crossScalaVersions := Seq("2.11.8", "2.12.1")
 
 version := "0.1.1"
 
-val akkaVersion = "2.4.17"
+val akkaVersion = "2.5.8"
 
 licenses := Seq("MIT" -> url("https://opensource.org/licenses/MIT"))
 
 homepage := Some(url("https://github.com/findify/akka-persistence-s3"))
 
 libraryDependencies ++= Seq(
-  "com.amazonaws" % "aws-java-sdk-core" % "1.11.105",
-  "com.amazonaws" % "aws-java-sdk-s3" % "1.11.105",
+  "com.amazonaws" % "aws-java-sdk-core" % "1.11.224",
+  "com.amazonaws" % "aws-java-sdk-s3" % "1.11.224",
   "com.typesafe.akka" %% "akka-persistence" % akkaVersion,
   "com.typesafe.akka" %% "akka-stream" % akkaVersion,
   "com.typesafe.akka" %% "akka-persistence-tck" % akkaVersion % "test",
@@ -24,7 +24,7 @@ libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "2.1.7" % "test",
   "commons-io" % "commons-io" % "2.4" % "test",
   "org.hdrhistogram" % "HdrHistogram" % "2.1.8" % "test",
-  "io.findify" %% "s3mock" % "0.1.10" % "test"
+  "io.findify" %% "s3mock" % "0.2.4" % "test"
 )
 
 parallelExecution in Test := false

--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "2.1.7" % "test",
   "commons-io" % "commons-io" % "2.4" % "test",
   "org.hdrhistogram" % "HdrHistogram" % "2.1.8" % "test",
-  "io.findify" %% "s3mock" % "0.1.9" % "test"
+  "io.findify" %% "s3mock" % "0.1.10" % "test"
 )
 
 parallelExecution in Test := false

--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "2.1.7" % "test",
   "commons-io" % "commons-io" % "2.4" % "test",
   "org.hdrhistogram" % "HdrHistogram" % "2.1.8" % "test",
-  "io.findify" %% "s3mock" % "0.1.10" % "test"
+  "io.findify" %% "s3mock" % "0.1.9" % "test"
 )
 
 parallelExecution in Test := false
@@ -36,11 +36,10 @@ publishTo := {
   if (isSnapshot.value)
     Some("snapshots" at nexus + "content/repositories/snapshots")
   else
-    Some("releases"  at nexus + "service/local/staging/deploy/maven2")
+    Some("releases" at nexus + "service/local/staging/deploy/maven2")
 }
 
-pomExtra := (
-  <scm>
+pomExtra := (<scm>
     <url>git@github.com:findify/akka-persistence-s3.git</url>
     <connection>scm:git:git@github.com:findify/akka-persistence-s3.git</connection>
   </scm>

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.9
+sbt.version=1.0.4

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.8.2")
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.0")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.0")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,9 +1,4 @@
 s3-client {
-  # The AWS key ID to use for connecting to the specified endpoint.
-  aws-access-key-id = ""
-
-  # The AWS secret to use in conjuction with the AWS key ID.
-  aws-secret-access-key = ""
 
   aws-use-default-credentials-provider-chain = false
 

--- a/src/main/scala/io/findify/akka/persistence/s3/S3Client.scala
+++ b/src/main/scala/io/findify/akka/persistence/s3/S3Client.scala
@@ -2,61 +2,73 @@ package io.findify.akka.persistence.s3
 
 import java.io.InputStream
 
-import com.amazonaws.auth.{BasicAWSCredentials, DefaultAWSCredentialsProviderChain}
+import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
 import com.amazonaws.services.s3.model._
-import com.amazonaws.services.s3.{AmazonS3Client, S3ClientOptions}
+import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
 
 import scala.concurrent.{ExecutionContext, Future}
 
 trait S3Client {
   val s3ClientConfig: S3ClientConfig
 
-  lazy val client: AmazonS3Client = {
-    val client =
-      if (s3ClientConfig.awsUseDefaultCredentialsProviderChain)
-        new AmazonS3Client(new DefaultAWSCredentialsProviderChain).withRegion(s3ClientConfig.region)
-      else
-        new AmazonS3Client(new BasicAWSCredentials(s3ClientConfig.awsKey, s3ClientConfig.awsSecret))
-
-    s3ClientConfig.endpoint.foreach { endpoint =>
-      client.withEndpoint(endpoint)
-      ()
+  lazy val client: AmazonS3 = {
+    val clientBuilder = AmazonS3ClientBuilder.standard()
+    s3ClientConfig.endpoint.fold(
+      clientBuilder.setRegion(s3ClientConfig.region.getName)
+    ) { endpoint =>
+      clientBuilder.setEndpointConfiguration(
+        new EndpointConfiguration(endpoint, s3ClientConfig.region.getName)
+      )
     }
-    client.setS3ClientOptions(new S3ClientOptions()
-      .withPathStyleAccess(s3ClientConfig.options.pathStyleAccess)
-      .withChunkedEncodingDisabled(s3ClientConfig.options.chunkedEncodingDisabled))
-    client
+
+    if (s3ClientConfig.options.pathStyleAccess)
+      clientBuilder.enablePathStyleAccess()
+
+    if (s3ClientConfig.options.chunkedEncodingDisabled)
+      clientBuilder.disableChunkedEncoding()
+
+    clientBuilder.build()
   }
 
-  def createBucket(bucketName: String)(implicit ec: ExecutionContext): Future[Bucket] = Future {
+  def createBucket(bucketName: String)(
+      implicit ec: ExecutionContext): Future[Bucket] = Future {
     client.createBucket(bucketName)
   }
 
-  def deleteBucket(bucketName: String)(implicit ec: ExecutionContext): Future[Unit] = Future {
+  def deleteBucket(bucketName: String)(
+      implicit ec: ExecutionContext): Future[Unit] = Future {
     client.deleteBucket(bucketName)
   }
 
-  def putObject(bucketName: String, key: String, input: InputStream, metadata: ObjectMetadata)(implicit ec: ExecutionContext): Future[PutObjectResult] = Future {
+  def putObject(bucketName: String,
+                key: String,
+                input: InputStream,
+                metadata: ObjectMetadata)(
+      implicit ec: ExecutionContext): Future[PutObjectResult] = Future {
     client.putObject(new PutObjectRequest(bucketName, key, input, metadata))
   }
 
-  def getObject(bucketName: String, key: String)(implicit ec: ExecutionContext): Future[S3Object] = Future {
+  def getObject(bucketName: String, key: String)(
+      implicit ec: ExecutionContext): Future[S3Object] = Future {
     val res = client.getObject(new GetObjectRequest(bucketName, key))
     println(res.toString)
-    val br=1
+    val br = 1
     res
   }
 
-  def listObjects(request: ListObjectsRequest)(implicit ec: ExecutionContext): Future[ObjectListing] = Future {
+  def listObjects(request: ListObjectsRequest)(
+      implicit ec: ExecutionContext): Future[ObjectListing] = Future {
     val list = client.listObjects(request)
     list
   }
 
-  def deleteObject(bucketName: String, key: String)(implicit ec: ExecutionContext): Future[Unit] = Future {
+  def deleteObject(bucketName: String, key: String)(
+      implicit ec: ExecutionContext): Future[Unit] = Future {
     client.deleteObject(bucketName, key)
   }
 
-  def deleteObjects(request: DeleteObjectsRequest)(implicit ec: ExecutionContext): Future[Unit] = Future {
+  def deleteObjects(request: DeleteObjectsRequest)(
+      implicit ec: ExecutionContext): Future[Unit] = Future {
     client.deleteObjects(request)
   }
 }

--- a/src/main/scala/io/findify/akka/persistence/s3/S3Config.scala
+++ b/src/main/scala/io/findify/akka/persistence/s3/S3Config.scala
@@ -1,6 +1,6 @@
 package io.findify.akka.persistence.s3
 
-import com.amazonaws.regions.{ Regions, Region }
+import com.amazonaws.regions.{Regions, Region}
 import com.typesafe.config.Config
 
 private object AWSRegionNames {
@@ -20,22 +20,20 @@ private object AWSRegionNames {
 
 class S3ClientConfig(config: Config) {
   import AWSRegionNames._
-  val awsKey = config getString "aws-access-key-id"
-  val awsSecret = config getString "aws-secret-access-key"
   val awsUseDefaultCredentialsProviderChain = config getBoolean "aws-use-default-credentials-provider-chain"
   val region: Region = config getString "region" match {
-    case GovCloud       => Region.getRegion(Regions.GovCloud)
-    case US_EAST_1      => Region.getRegion(Regions.US_EAST_1)
-    case US_WEST_1      => Region.getRegion(Regions.US_WEST_1)
-    case US_WEST_2      => Region.getRegion(Regions.US_WEST_2)
-    case EU_WEST_1      => Region.getRegion(Regions.EU_WEST_1)
-    case EU_CENTRAL_1   => Region.getRegion(Regions.EU_CENTRAL_1)
+    case GovCloud => Region.getRegion(Regions.GovCloud)
+    case US_EAST_1 => Region.getRegion(Regions.US_EAST_1)
+    case US_WEST_1 => Region.getRegion(Regions.US_WEST_1)
+    case US_WEST_2 => Region.getRegion(Regions.US_WEST_2)
+    case EU_WEST_1 => Region.getRegion(Regions.EU_WEST_1)
+    case EU_CENTRAL_1 => Region.getRegion(Regions.EU_CENTRAL_1)
     case AP_SOUTHEAST_1 => Region.getRegion(Regions.AP_SOUTHEAST_1)
     case AP_SOUTHEAST_2 => Region.getRegion(Regions.AP_SOUTHEAST_2)
     case AP_NORTHEAST_1 => Region.getRegion(Regions.AP_NORTHEAST_1)
     case AP_NORTHEAST_2 => Region.getRegion(Regions.AP_NORTHEAST_2)
-    case SA_EAST_1      => Region.getRegion(Regions.SA_EAST_1)
-    case CN_NORTH_1     => Region.getRegion(Regions.CN_NORTH_1)
+    case SA_EAST_1 => Region.getRegion(Regions.SA_EAST_1)
+    case CN_NORTH_1 => Region.getRegion(Regions.CN_NORTH_1)
   }
   val endpoint: Option[String] = {
     val e = config getString "endpoint"

--- a/src/test/scala/io/findify/akka/persistence/s3/snapshot/S3SnapshotStorePrefixSpec.scala
+++ b/src/test/scala/io/findify/akka/persistence/s3/snapshot/S3SnapshotStorePrefixSpec.scala
@@ -32,7 +32,7 @@ class S3SnapshotStorePrefixSpec
     with SnapshotKeySupport {
 
   var s3Client: S3Client = _
-  var s3mock: S3Mock = new S3Mock(4567, new FileProvider("/tmp/s3snap"))
+  var s3mock: S3Mock = new S3Mock(4567, new FileProvider("/tmp/s3prefSnap"))
   val bucketName = "snapshot"
 
   val extensionName: String = "ss"

--- a/src/test/scala/io/findify/akka/persistence/s3/snapshot/S3SnapshotStorePrefixSpec.scala
+++ b/src/test/scala/io/findify/akka/persistence/s3/snapshot/S3SnapshotStorePrefixSpec.scala
@@ -1,24 +1,25 @@
 package io.findify.akka.persistence.s3.snapshot
 
-import java.io.File
-
 import akka.persistence.snapshot.SnapshotStoreSpec
 import com.typesafe.config.ConfigFactory
 import io.findify.akka.persistence.s3.{S3Client, S3ClientConfig}
 import io.findify.s3mock.S3Mock
+import io.findify.s3mock.provider.FileProvider
+
 import scala.concurrent.duration._
 import scala.concurrent.Await
 
 /**
   * Created by shutty on 3/16/17.
   */
-class S3SnapshotStorePrefixSpec  extends SnapshotStoreSpec(ConfigFactory.parseString(
-  """
+class S3SnapshotStorePrefixSpec
+    extends SnapshotStoreSpec(
+      ConfigFactory
+        .parseString(
+          """
     |akka.persistence.snapshot-store.plugin = "s3-snapshot-store"
     |s3-client{
-    |  aws-access-key-id = "test"
-    |  aws-secret-access-key = "test"
-    |  region = "us-west-2"
+    |  region = "eu-west-1"
     |  endpoint = "http://localhost:4567"
     |  options {
     |    path-style-access = true
@@ -26,21 +27,22 @@ class S3SnapshotStorePrefixSpec  extends SnapshotStoreSpec(ConfigFactory.parseSt
     |}
     |s3-snapshot-store.prefix = "foo/"
   """.stripMargin
-).withFallback(ConfigFactory.load())) with SnapshotKeySupport {
+        )
+        .withFallback(ConfigFactory.load()))
+    with SnapshotKeySupport {
 
   var s3Client: S3Client = _
-  var s3mock: S3Mock = S3Mock.create(4567, "/tmp/s3snap")
+  var s3mock: S3Mock = new S3Mock(4567, new FileProvider("/tmp/s3snap"))
   val bucketName = "snapshot"
 
   val extensionName: String = "ss"
 
   override def beforeAll() = {
     import system.dispatcher
-    val dir = new File("/tmp/s3snap")
-    if (dir.exists()) dir.delete()
     s3mock.start
     s3Client = new S3Client {
-      override val s3ClientConfig: S3ClientConfig = new S3ClientConfig(system.settings.config.getConfig("s3-client"))
+      override val s3ClientConfig: S3ClientConfig = new S3ClientConfig(
+        system.settings.config.getConfig("s3-client"))
     }
     Await.result(s3Client.createBucket(bucketName), 5 seconds)
     println(s"""bucket `$bucketName` created""")
@@ -52,4 +54,3 @@ class S3SnapshotStorePrefixSpec  extends SnapshotStoreSpec(ConfigFactory.parseSt
     super.afterAll()
   }
 }
-

--- a/src/test/scala/io/findify/akka/persistence/s3/snapshot/S3SnapshotStoreSpec.scala
+++ b/src/test/scala/io/findify/akka/persistence/s3/snapshot/S3SnapshotStoreSpec.scala
@@ -1,44 +1,44 @@
 package io.findify.akka.persistence.s3.snapshot
 
-import java.io.File
-
 import akka.persistence.snapshot.SnapshotStoreSpec
 import com.typesafe.config.ConfigFactory
 import io.findify.akka.persistence.s3.{S3Client, S3ClientConfig}
 import io.findify.s3mock.S3Mock
+import io.findify.s3mock.provider.FileProvider
 
 import scala.concurrent.duration._
-import scala.concurrent.{Await, Future}
-import scala.collection.JavaConversions._
+import scala.concurrent.{Await}
 
-class S3SnapshotStoreSpec extends SnapshotStoreSpec(ConfigFactory.parseString(
-  """
+class S3SnapshotStoreSpec
+    extends SnapshotStoreSpec(
+      ConfigFactory
+        .parseString(
+          """
     |akka.persistence.snapshot-store.plugin = "s3-snapshot-store"
     |s3-client{
-    |  aws-access-key-id = "test"
-    |  aws-secret-access-key = "test"
     |  region = "us-west-2"
-    |  endpoint = "http://localhost:4567"
+    |  endpoint = "http://127.0.0.1:4567"
     |  options {
     |    path-style-access = true
     |  }
     |}
   """.stripMargin
-).withFallback(ConfigFactory.load())) with SnapshotKeySupport {
+        )
+        .withFallback(ConfigFactory.load()))
+    with SnapshotKeySupport {
 
   var s3Client: S3Client = _
-  var s3mock: S3Mock = S3Mock.create(4567, "/tmp/s3snap")
+  var s3mock: S3Mock = new S3Mock(4567, new FileProvider("/tmp/s3snap"))
   val bucketName = "snapshot"
 
   val extensionName: String = "ss"
 
   override def beforeAll() = {
     import system.dispatcher
-    val dir = new File("/tmp/s3snap")
-    if (dir.exists()) dir.delete()
     s3mock.start
     s3Client = new S3Client {
-      override val s3ClientConfig: S3ClientConfig = new S3ClientConfig(system.settings.config.getConfig("s3-client"))
+      override val s3ClientConfig: S3ClientConfig = new S3ClientConfig(
+        system.settings.config.getConfig("s3-client"))
     }
     Await.result(s3Client.createBucket(bucketName), 5 seconds)
     println(s"""bucket `$bucketName` created""")


### PR DESCRIPTION
Hello,

In aws normally we have the keys in environment variables or configuration files in the server's filesystem. I was just curious if you are interested in the particular PR with that kind of changes.

Also, on my system the S3Mock server wasn't working, I think it was because of the delete. I changed it to be as in the main of S3Mock project.

I've also removed the deprecated amazon client and used a builder to create the s3 client. Let me know if you are interested in these changes or a subset of them and I'll clean it up for you (along with the code formatting that I accidentally changed).

I've tested it in our aws infrastructure and it works ok.

Cheers,
Vasilis  